### PR TITLE
Minor improvement for food selection algorithm

### DIFF
--- a/bot.user.js
+++ b/bot.user.js
@@ -586,10 +586,9 @@ window.computeFoodGoal = function() {
                 bestClusterX = clusterSumX / clusterSize;
                 bestClusterY = clusterSumY / clusterSize;
                 bestClusterIndx = i;
-                console.log(clusterSize);
             }
         }
-        window.currentFood = window.sortedFood[bestClusterIndx];
+
         window.currentFoodX = bestClusterX;
         window.currentFoodY = bestClusterY;
 

--- a/bot.user.js
+++ b/bot.user.js
@@ -555,6 +555,8 @@ window.computeFoodGoal = function() {
         var bestClusterIndx = 0;
         var bestClusterScore = 0;
         var bestClusterAbsScore = 0;
+        var bestClusterX = 0;
+        var bestClusterY = 0;
 
         // there is no need to view more points (for performance)
         var nIter = Math.min(window.sortedFood.length, 300);
@@ -562,26 +564,34 @@ window.computeFoodGoal = function() {
             var clusterScore = 0;
             var clusterSize = 0;
             var clusterAbsScore = 0;
+            var clusterSumX = 0;
+            var clusterSumY = 0;
+
             var p1 = window.sortedFood[i];
             for (var j = 0; j < nIter; ++j) {
                 var p2 = window.sortedFood[j];
                 var dist = window.getDistance(p1.xx, p1.yy, p2.xx, p2.yy);
                 if (dist < 100) {
                     clusterScore += p2.sz;
+                    clusterSumX += p2.xx;
+                    clusterSumY += p2.yy;
                     clusterSize += 1;
                 }
             }
             clusterAbsScore = clusterScore;
-            clusterScore /= p1.distance * Math.sqrt(p1.distance);
+            clusterScore /= Math.pow(p1.distance, 1.5);
             if (clusterSize > 2 && clusterScore > bestClusterScore) {
                 bestClusterScore = clusterScore;
                 bestClusterAbsScore = clusterAbsScore;
+                bestClusterX = clusterSumX / clusterSize;
+                bestClusterY = clusterSumY / clusterSize;
                 bestClusterIndx = i;
+                console.log(clusterSize);
             }
         }
         window.currentFood = window.sortedFood[bestClusterIndx];
-        window.currentFoodX = window.currentFood.xx;
-        window.currentFoodY = window.currentFood.yy;
+        window.currentFoodX = bestClusterX;
+        window.currentFoodY = bestClusterY;
 
         // if see a large cluster then use acceleration
         if (bestClusterAbsScore > 50) {

--- a/bot.user.js
+++ b/bot.user.js
@@ -350,8 +350,6 @@ window.getSnakeWidth = function() {
 };
 // Sorting function for food, from property 'distance'
 window.sortFood = function(a, b) {
-    // a.sz & b.sz - size
-    // Divide distance by size so bigger food is prioritised over smaller food
     return a.distance - b.distance;
 };
 // Sorting function for prey, from property 'distance'
@@ -556,13 +554,14 @@ window.computeFoodGoal = function() {
 
         var bestClusterIndx = 0;
         var bestClusterScore = 0;
-        var bestClusterSize = 0;
+        var bestClusterAbsScore = 0;
 
         // there is no need to view more points (for performance)
         var nIter = Math.min(window.sortedFood.length, 300);
         for (var i = 0; i < nIter; i += 2) {
             var clusterScore = 0;
             var clusterSize = 0;
+            var clusterAbsScore = 0;
             var p1 = window.sortedFood[i];
             for (var j = 0; j < nIter; ++j) {
                 var p2 = window.sortedFood[j];
@@ -572,10 +571,11 @@ window.computeFoodGoal = function() {
                     clusterSize += 1;
                 }
             }
-            clusterScore /= p1.distance;
+            clusterAbsScore = clusterScore;
+            clusterScore /= p1.distance * Math.sqrt(p1.distance);
             if (clusterSize > 2 && clusterScore > bestClusterScore) {
                 bestClusterScore = clusterScore;
-                bestClusterSize = clusterScore * p1.distance;
+                bestClusterAbsScore = clusterAbsScore;
                 bestClusterIndx = i;
             }
         }
@@ -584,7 +584,7 @@ window.computeFoodGoal = function() {
         window.currentFoodY = window.currentFood.yy;
 
         // if see a large cluster then use acceleration
-        if (bestClusterSize > 50) {
+        if (bestClusterAbsScore > 50) {
             window.foodAcceleration = 1;
         } else {
             window.foodAcceleration = 0;

--- a/bot.user.js
+++ b/bot.user.js
@@ -573,8 +573,8 @@ window.computeFoodGoal = function() {
                 var dist = window.getDistance(p1.xx, p1.yy, p2.xx, p2.yy);
                 if (dist < 100) {
                     clusterScore += p2.sz;
-                    clusterSumX += p2.xx;
-                    clusterSumY += p2.yy;
+                    clusterSumX += p2.xx * p2.sz;
+                    clusterSumY += p2.yy * p2.sz;
                     clusterSize += 1;
                 }
             }
@@ -583,8 +583,8 @@ window.computeFoodGoal = function() {
             if (clusterSize > 2 && clusterScore > bestClusterScore) {
                 bestClusterScore = clusterScore;
                 bestClusterAbsScore = clusterAbsScore;
-                bestClusterX = clusterSumX / clusterSize;
-                bestClusterY = clusterSumY / clusterSize;
+                bestClusterX = clusterSumX / clusterAbsScore;
+                bestClusterY = clusterSumY / clusterAbsScore;
                 bestClusterIndx = i;
             }
         }


### PR DESCRIPTION
## Description

1) Use cluster_weight / (dist \* sqrt(dist)) for cluster score instead cluster_weight/dist.
2) Bot selects the center of mass of the cluster as a goal now.
## Motivation and Context

It seems to work better.
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
