### PR TITLE
Fix bot disabling issues

### DIFF
--- a/bot.user.js
+++ b/bot.user.js
@@ -178,6 +178,8 @@ window.launchBot = function() {
 // Stops the bot
 window.stopBot = function() {
     window.log('Stopping Bot.');
+	// Disable the "sprint"
+    window.setAcceleration(0);
     // Re enable the original onmousemove function
     window.onmousemove = window.mousemovelistener;
     window.isBotRunning = false;
@@ -354,7 +356,7 @@ window.onmousedown = function(e) {
                 // "Left click" to manually speed up the slither
                 case 1:
                     window.setAcceleration(1);
-                    window.log('Enabling manual speed...');
+                    window.log('Manual boost...');
                     break;
                     // "Right click" to toggle bot in addition to the letter "T"
                 case 3:


### PR DESCRIPTION
## Description

When executing the stopBot()-function, setAcceleration back to 0.
## Motivation and Context

When turning off the bot while it was boosting, the acceleration wasn't disabled; fixes issue #90.
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
